### PR TITLE
Remove the rubywarden user .ssh directory.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,11 @@
     group: "{{ rw_group }}"
     append: yes
 
+- name: remove rubywarden .ssh directory
+  file:
+    state: absent
+    path: "{{ rw_home }}/.ssh"
+
 - name: get rubywarden code
   register: git_updated
   git:


### PR DESCRIPTION
Prevents nightly security notification regarding the user having a valid login shell and alternate access mechanisms.

This meets my personal needs. However, I don't know if others might have added public keys or whatnot..